### PR TITLE
Client.prototype.get should return (error, result) when retrieving from cache

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -287,7 +287,7 @@ Client.prototype.get = function(url, data, callback) {
     return this.getCacheResult(url, data).then(function(result) {
       if (result) {
         if (callback) {
-          return callback(result);
+          return callback(null, result);
         }
         return result;
       }

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -456,6 +456,24 @@ describe('Client', function() {
       assert.deepEqual(requestStub.args[0].slice(1), requestArgs);
     });
 
+    it('get request returns (error, response) when retrieving from cache', function() {
+      var returnValue = 'response';
+      sinon.stub(Schema.Client.prototype, 'getCacheResult').returns(Promise.resolve(returnValue));
+
+      client = new Schema.Client();
+      client.cache = true;
+
+      var calledBack = false;
+
+      client.get('url', 'data', function(error, response) {
+        assert.strictEqual(error, null);
+        assert.strictEqual(response, returnValue);
+        calledBack = true;
+      }).then(function() {
+        assert.strictEqual(calledBack, true)
+      });
+    });
+
     it('put request', function() {
       client.put.apply(client, requestArgs);
 


### PR DESCRIPTION
This should address https://github.com/schemaio/schema-node-client/issues/3

Let me know if any tweaks are needed.