### PR TITLE
Callback should fire even when it's 2nd param in cached get request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -284,6 +284,12 @@ Client.prototype.respond = function(method, url, request, response, callback) {
 Client.prototype.get = function(url, data, callback) {
   if (this.cache) {
     var self = this;
+
+    if (typeof data === 'function') {
+      callback = data;
+      data = null;
+    }
+
     return this.getCacheResult(url, data).then(function(result) {
       if (result) {
         if (callback) {

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -471,21 +471,37 @@ describe('Client', function() {
       assert.deepEqual(requestStub.args[0].slice(1), requestArgs);
     });
 
-    it('get request returns (error, response) when retrieving from cache', function() {
+    describe('get request caching behaviour', function() {
       var returnValue = 'response';
-      sinon.stub(Schema.Client.prototype, 'getCacheResult').returns(Promise.resolve(returnValue));
+      var getCacheResultStub = sinon.stub(Schema.Client.prototype, 'getCacheResult').returns(Promise.resolve(returnValue));
 
-      client = new Schema.Client();
+      var client = new Schema.Client();
       client.cache = true;
 
-      var calledBack = false;
+      after(function() {
+        getCacheResultStub.restore();
+      })
 
-      client.get('url', 'data', function(error, response) {
-        assert.strictEqual(error, null);
-        assert.strictEqual(response, returnValue);
-        calledBack = true;
-      }).then(function() {
-        assert.strictEqual(calledBack, true)
+      it('returns (error, response) when retrieving from cache', function() {
+        var calledBack = false;
+
+        return client.get('url', 'data', function(error, response) {
+          assert.strictEqual(error, null);
+          assert.strictEqual(response, returnValue);
+          calledBack = true;
+        }).then(function() {
+          assert.strictEqual(calledBack, true);
+        });
+      });
+
+      it('fires callback when no request params present (callback 2nd param)', function() {
+        var calledBack = false;
+
+        return client.get('url', function() {
+          calledBack = true;
+        }).then(function() {
+          assert.strictEqual(calledBack, true);
+        });
       });
     });
 


### PR DESCRIPTION
So as stated in the title, right now the callback provided to `Client.prototype.get` doesn't fire because it doesn't check for whether `data` is a function. This pull request fixes that and provides a test. I've also made a minor adjustment to an earlier test I included which wasn't correctly cleaning up after itself.